### PR TITLE
Fix method name connectToHostname

### DIFF
--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -132,7 +132,7 @@
         NSNumber *port = [url port];
         NSString *username = [url user];
         NSString *password = [url password];
-        [connController connetToHostname:hostname port:port ? [port integerValue] : 64738 withUsername:username andPassword:password withParentViewController:welcomeScreen];
+        [connController connectToHostname:hostname port:port ? [port integerValue] : 64738 withUsername:username andPassword:password withParentViewController:welcomeScreen];
         return YES;
     }
     return NO;
@@ -148,7 +148,7 @@
         NSNumber *port = [url port];
         NSString *username = [url user];
         NSString *password = [url password];
-        [connController connetToHostname:hostname port:port ? [port integerValue] : 64738 withUsername:username andPassword:password withParentViewController:_navigationController.visibleViewController];
+        [connController connectToHostname:hostname port:port ? [port integerValue] : 64738 withUsername:username andPassword:password withParentViewController:_navigationController.visibleViewController];
         return YES;
     }
     return NO;

--- a/Source/Classes/MUConnectionController.h
+++ b/Source/Classes/MUConnectionController.h
@@ -7,7 +7,7 @@ extern NSString *MUConnectionClosedNotification;
 
 @interface MUConnectionController : UIView
 + (MUConnectionController *) sharedController;
-- (void) connetToHostname:(NSString *)hostName port:(NSUInteger)port withUsername:(NSString *)userName andPassword:(NSString *)password withParentViewController:(UIViewController *)parentViewController;
+- (void) connectToHostname:(NSString *)hostName port:(NSUInteger)port withUsername:(NSString *)userName andPassword:(NSString *)password withParentViewController:(UIViewController *)parentViewController;
 - (BOOL) isConnected;
 - (void) disconnectFromServer;
 @end

--- a/Source/Classes/MUConnectionController.m
+++ b/Source/Classes/MUConnectionController.m
@@ -69,7 +69,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     [_transitioningDelegate release];
 }
 
-- (void) connetToHostname:(NSString *)hostName port:(NSUInteger)port withUsername:(NSString *)userName andPassword:(NSString *)password withParentViewController:(UIViewController *)parentViewController {
+- (void) connectToHostname:(NSString *)hostName port:(NSUInteger)port withUsername:(NSString *)userName andPassword:(NSString *)password withParentViewController:(UIViewController *)parentViewController {
     _hostname = [hostName retain];
     _port = port;
     _username = [userName retain];

--- a/Source/Classes/MUCountryServerListController.m
+++ b/Source/Classes/MUCountryServerListController.m
@@ -214,7 +214,7 @@
     
     if (buttonIndex == 1) {
         MUConnectionController *connCtrlr = [MUConnectionController sharedController];
-        [connCtrlr connetToHostname:[serverItem objectForKey:@"ip"]
+        [connCtrlr connectToHostname:[serverItem objectForKey:@"ip"]
                                port:[[serverItem objectForKey:@"port"] intValue]
                        withUsername:[[alertView textFieldAtIndex:0] text]
                         andPassword:nil

--- a/Source/Classes/MUFavouriteServerListController.m
+++ b/Source/Classes/MUFavouriteServerListController.m
@@ -174,7 +174,7 @@
         }
         
         MUConnectionController *connCtrlr = [MUConnectionController sharedController];
-        [connCtrlr connetToHostname:[favServ hostName]
+        [connCtrlr connectToHostname:[favServ hostName]
                                port:[favServ port]
                             withUsername:userName
                         andPassword:[favServ password]

--- a/Source/Classes/MULanServerListController.m
+++ b/Source/Classes/MULanServerListController.m
@@ -218,7 +218,7 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
 
     if (buttonIndex == 1) {
         MUConnectionController *connCtrlr = [MUConnectionController sharedController];
-        [connCtrlr connetToHostname:[netService hostName]
+        [connCtrlr connectToHostname:[netService hostName]
                                port:[netService port]
                        withUsername:[[alertView textFieldAtIndex:0] text]
                         andPassword:nil


### PR DESCRIPTION
## Summary
- fix the typo in MUConnectionController
- update all call sites to use `connectToHostname`

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d1fa0af08330b7f986eccadeac77