### PR TITLE
Fix shebang for country plist script

### DIFF
--- a/Scripts/gen-country-plist.py
+++ b/Scripts/gen-country-plist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python2.6
+#!/usr/bin/env python2.6
 # -*- coding: utf-8 -*-
 #
 # Generate a country plist from the GeoLite GeoIP CSV file.


### PR DESCRIPTION
## Summary
- update the shebang in `gen-country-plist.py`
- make sure the script is executable

## Testing
- `python3 -m py_compile Scripts/gen-country-plist.py`


------
https://chatgpt.com/codex/tasks/task_e_6840d07ed5c08330b125a57b63ea112d