### PR TITLE
Update deprecated APIs

### DIFF
--- a/Source/Classes/MUConnectionController.m
+++ b/Source/Classes/MUConnectionController.m
@@ -23,12 +23,10 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     MKServerModel              *_serverModel;
     MUServerRootViewController *_serverRoot;
     UIViewController           *_parentViewController;
-    UIAlertView                *_alertView;
+    UIAlertController          *_alertView;
     NSTimer                    *_timer;
     int                        _numDots;
 
-    UIAlertView                *_rejectAlertView;
-    MKRejectReason             _rejectReason;
 
     NSString                   *_hostname;
     NSUInteger                 _port;
@@ -96,17 +94,21 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
                         NSLocalizedString(@"Connecting to %@:%lu", @"Connecting to hostname:port"),
                             _hostname, (unsigned long)_port];
     
-    _alertView = [[UIAlertView alloc] initWithTitle:title
-                                            message:msg
-                                           delegate:self
-                                  cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                  otherButtonTitles:nil];
-    [_alertView show];
+    _alertView = [[UIAlertController alertControllerWithTitle:title
+                                                     message:msg
+                                              preferredStyle:UIAlertControllerStyleAlert] retain];
+    UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                     style:UIAlertActionStyleCancel
+                                                   handler:^(UIAlertAction *action) {
+                                                       [self teardownConnection];
+                                                   }];
+    [_alertView addAction:cancel];
+    [_parentViewController presentViewController:_alertView animated:YES completion:nil];
     _timer = [NSTimer scheduledTimerWithTimeInterval:0.2f target:self selector:@selector(updateTitle) userInfo:nil repeats:YES];
 }
 
 - (void) hideConnectingView {
-    [_alertView dismissWithClickedButtonIndex:1 animated:YES];
+    [_alertView dismissViewControllerAnimated:YES completion:nil];
     [_alertView release];
     _alertView = nil;
     [_timer invalidate];
@@ -171,7 +173,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     if (_numDots == 2) { dots = @".. "; }
     if (_numDots == 3) { dots = @"..."; }
     
-    [_alertView setTitle:[NSString stringWithFormat:@"%@%@", NSLocalizedString(@"Connecting", nil), dots]];
+    _alertView.title = [NSString stringWithFormat:@"%@%@", NSLocalizedString(@"Connecting", nil), dots];
 }
 
 #pragma mark - MKConnectionDelegate
@@ -184,14 +186,14 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
 - (void) connection:(MKConnection *)conn closedWithError:(NSError *)err {
     [self hideConnectingView];
     if (err) {
-        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Connection closed", nil)
-                                                            message:[err localizedDescription]
-                                                           delegate:nil
-                                                  cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                                  otherButtonTitles:nil];
-        [alertView show];
-        [alertView release];
-        [self teardownConnection];
+        UIAlertController *alertView = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Connection closed", nil)
+                                                                           message:[err localizedDescription]
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *ok = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){
+            [self teardownConnection];
+        }];
+        [alertView addAction:ok];
+        [_parentViewController presentViewController:alertView animated:YES completion:nil];
     }
 }
 
@@ -215,14 +217,16 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
                                 @"attempted to connect too many times in a row.", nil);
     }
     
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Unable to connect", nil)
-                                                        message:msg
-                                                       delegate:nil
-                                              cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                              otherButtonTitles:nil];
-    [alertView show];
-    [alertView release];
-    [self teardownConnection];
+    UIAlertController *alertView = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Unable to connect", nil)
+                                                                       message:msg
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *ok = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                 style:UIAlertActionStyleDefault
+                                               handler:^(UIAlertAction *action){
+                                                   [self teardownConnection];
+                                               }];
+    [alertView addAction:ok];
+    [_parentViewController presentViewController:alertView animated:YES completion:nil];
 }
 
 // The connection encountered an invalid SSL certificate chain.
@@ -243,16 +247,18 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
             [self hideConnectingView];
             NSString *title = NSLocalizedString(@"Certificate Mismatch", nil);
             NSString *msg = NSLocalizedString(@"The server presented a different certificate than the one stored for this server", nil);
-            UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title
-                                                            message:msg
-                                                           delegate:self
-                                                  cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                                  otherButtonTitles:nil];
-            [alert addButtonWithTitle:NSLocalizedString(@"Ignore", nil)];
-            [alert addButtonWithTitle:NSLocalizedString(@"Trust New Certificate", nil)];
-            [alert addButtonWithTitle:NSLocalizedString(@"Show Certificates", nil)];
-            [alert show];
-            [alert release];
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                           message:msg
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:UIAlertActionStyleCancel handler:^(UIAlertAction *action){ [self teardownConnection]; }];
+            UIAlertAction *ignore = [UIAlertAction actionWithTitle:NSLocalizedString(@"Ignore", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){ [_connection setIgnoreSSLVerification:YES]; [_connection reconnect]; [self showConnectingView]; }];
+            UIAlertAction *trust = [UIAlertAction actionWithTitle:NSLocalizedString(@"Trust New Certificate", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){ MKCertificate *cert = [[_connection peerCertificates] objectAtIndex:0]; NSString *digest = [cert hexDigest]; [MUDatabase storeDigest:digest forServerWithHostname:[_connection hostname] port:[_connection port]]; [_connection setIgnoreSSLVerification:YES]; [_connection reconnect]; [self showConnectingView]; }];
+            UIAlertAction *show = [UIAlertAction actionWithTitle:NSLocalizedString(@"Show Certificates", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action){ MUServerCertificateTrustViewController *certTrustView = [[MUServerCertificateTrustViewController alloc] initWithCertificates:[_connection peerCertificates]]; [certTrustView setDelegate:self]; UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:certTrustView]; [certTrustView release]; [_parentViewController presentModalViewController:navCtrl animated:YES]; [navCtrl release]; }];
+            [alert addAction:cancel];
+            [alert addAction:ignore];
+            [alert addAction:trust];
+            [alert addAction:show];
+            [_parentViewController presentViewController:alert animated:YES completion:nil];
         }
     } else {
         // No certhash of this certificate in the database for this hostname-port combo.  Let the user decide
@@ -277,7 +283,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
 - (void) connection:(MKConnection *)conn rejectedWithReason:(MKRejectReason)reason explanation:(NSString *)explanation {
     NSString *title = NSLocalizedString(@"Connection Rejected", nil);
     NSString *msg = nil;
-    UIAlertView *alert = nil;
+    UIAlertController *alert = nil;
     
     [self hideConnectingView];
     [self teardownConnection];
@@ -285,84 +291,119 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     switch (reason) {
         case MKRejectReasonNone:
             msg = NSLocalizedString(@"No reason", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:nil
-                                     cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                     otherButtonTitles:nil];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:nil]];
             break;
         case MKRejectReasonWrongVersion:
             msg = @"Client/server version mismatch";
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:nil
-                                     cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                     otherButtonTitles:nil];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:nil]];
 
             break;
         case MKRejectReasonInvalidUsername:
             msg = NSLocalizedString(@"Invalid username", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:self
-                                     cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                     otherButtonTitles:NSLocalizedString(@"Reconnect", nil), nil];
-            [alert setAlertViewStyle:UIAlertViewStylePlainTextInput];
-            [[alert textFieldAtIndex:0] setText:_username];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addTextFieldWithConfigurationHandler:^(UITextField *tf){ tf.text = _username; }];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                      style:UIAlertActionStyleCancel
+                                                    handler:nil]];
+            __weak UIAlertController *weakAlert = alert;
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Reconnect", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:^(UIAlertAction *a){
+                                                        [_username release];
+                                                        _username = [[weakAlert.textFields[0] text] copy];
+                                                        [self establishConnection];
+                                                        [self showConnectingView];
+                                                    }]];
             break;
         case MKRejectReasonWrongUserPassword:
             msg = NSLocalizedString(@"Wrong certificate or password for existing user", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:self
-                                     cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                     otherButtonTitles:NSLocalizedString(@"Reconnect", nil), nil];
-            [alert setAlertViewStyle:UIAlertViewStyleSecureTextInput];
-            [[alert textFieldAtIndex:0] setText:_password];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addTextFieldWithConfigurationHandler:^(UITextField *tf){ tf.secureTextEntry = YES; tf.text = _password; }];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                      style:UIAlertActionStyleCancel
+                                                    handler:nil]];
+            __weak UIAlertController *weakAlertPW = alert;
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Reconnect", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:^(UIAlertAction *a){
+                                                        [_password release];
+                                                        _password = [[weakAlertPW.textFields[0] text] copy];
+                                                        [self establishConnection];
+                                                        [self showConnectingView];
+                                                    }]];
             break;
         case MKRejectReasonWrongServerPassword:
             msg = NSLocalizedString(@"Wrong server password", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:self
-                                     cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                     otherButtonTitles:NSLocalizedString(@"Reconnect", nil), nil];
-            [alert setAlertViewStyle:UIAlertViewStyleSecureTextInput];
-            [[alert textFieldAtIndex:0] setText:_password];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addTextFieldWithConfigurationHandler:^(UITextField *tf){ tf.secureTextEntry = YES; tf.text = _password; }];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                      style:UIAlertActionStyleCancel
+                                                    handler:nil]];
+            __weak UIAlertController *weakAlertPW2 = alert;
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Reconnect", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:^(UIAlertAction *a){
+                                                        [_password release];
+                                                        _password = [[weakAlertPW2.textFields[0] text] copy];
+                                                        [self establishConnection];
+                                                        [self showConnectingView];
+                                                    }]];
             break;
         case MKRejectReasonUsernameInUse:
             msg = NSLocalizedString(@"Username already in use", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:self
-                                     cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                     otherButtonTitles:NSLocalizedString(@"Reconnect", nil), nil];
-            [alert setAlertViewStyle:UIAlertViewStylePlainTextInput];
-            [[alert textFieldAtIndex:0] setText:_username];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addTextFieldWithConfigurationHandler:^(UITextField *tf){ tf.text = _username; }];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                      style:UIAlertActionStyleCancel
+                                                    handler:nil]];
+            __weak UIAlertController *weakAlert2 = alert;
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Reconnect", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:^(UIAlertAction *a){
+                                                        [_username release];
+                                                        _username = [[weakAlert2.textFields[0] text] copy];
+                                                        [self establishConnection];
+                                                        [self showConnectingView];
+                                                    }]];
             break;
         case MKRejectReasonServerIsFull:
             msg = NSLocalizedString(@"Server is full", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:nil
-                                     cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                     otherButtonTitles:nil];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:nil]];
             break;
         case MKRejectReasonNoCertificate:
             msg = NSLocalizedString(@"A certificate is needed to connect to this server", nil);
-            alert = [[UIAlertView alloc] initWithTitle:title
-                                               message:msg
-                                              delegate:nil
-                                     cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                     otherButtonTitles:nil];
+            alert = [UIAlertController alertControllerWithTitle:title
+                                                        message:msg
+                                                 preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:nil]];
             break;
     }
-
-    _rejectAlertView = alert;
-    _rejectReason = reason;
-
-    [alert show];
-    [alert release];
+    [_parentViewController presentViewController:alert animated:YES completion:nil];
 }
 
 #pragma mark - MKServerModelDelegate
@@ -394,79 +435,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     _parentViewController = nil;
 }
 
-#pragma mark - UIAlertView delegate
-
-- (void) alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
-    
-    // Actions for the outermost UIAlertView
-    if (alertView == _alertView) {
-        if (buttonIndex == 0) {
-            [self teardownConnection];
-        } else if (buttonIndex == 1) {
-            // ... nope.
-        }
-        return;
-    }
-    
-    // Actions for the rejection UIAlertView
-    if (alertView == _rejectAlertView) {
-        if (_rejectReason == MKRejectReasonInvalidUsername || _rejectReason == MKRejectReasonUsernameInUse) {
-            [_username release];
-            UITextField *textField = [_rejectAlertView textFieldAtIndex:0];
-            _username = [[textField text] copy];
-        } else if (_rejectReason == MKRejectReasonWrongServerPassword || _rejectReason == MKRejectReasonWrongUserPassword) {
-            [_password release];
-            UITextField *textField = [_rejectAlertView textFieldAtIndex:0];
-            _password = [[textField text] copy];
-        }
-
-        if (buttonIndex == 0) {
-            // Rejection handler has already handled the teardown for us.
-        } else if (buttonIndex == 1) {
-            [self establishConnection];
-            [self showConnectingView];
-        }
-        return;
-    }
-    
-    // Actions that follow are for the certificate trust alert view
-    
-    // Cancel
-    if (buttonIndex == 0) {
-        // Tear down the connection.
-        [self teardownConnection];
-        
-    // Ignore
-    } else if (buttonIndex == 1) {
-        // Ignore just reconnects to the server without
-        // performing any verification on the certificate chain
-        // the server presents us.
-        [_connection setIgnoreSSLVerification:YES];
-        [_connection reconnect];
-        [self showConnectingView];
-        
-    // Trust
-    } else if (buttonIndex == 2) {
-        // Store the cert hash of the leaf certificate.  We then ignore certificate
-        // verification errors from this host as long as it keeps on presenting us
-        // the same certificate it always has.
-        MKCertificate *cert = [[_connection peerCertificates] objectAtIndex:0];
-        NSString *digest = [cert hexDigest];
-        [MUDatabase storeDigest:digest forServerWithHostname:[_connection hostname] port:[_connection port]];
-        [_connection setIgnoreSSLVerification:YES];
-        [_connection reconnect];
-        [self showConnectingView];
-        
-    // Show certificates
-    } else if (buttonIndex == 3) {
-        MUServerCertificateTrustViewController *certTrustView = [[MUServerCertificateTrustViewController alloc] initWithCertificates:[_connection peerCertificates]];
-        [certTrustView setDelegate:self];
-        UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:certTrustView];
-        [certTrustView release];
-        [_parentViewController presentModalViewController:navCtrl animated:YES];
-        [navCtrl release];
-    }
-}
 
 - (void) serverCertificateTrustViewControllerDidDismiss:(MUServerCertificateTrustViewController *)trustView {
     [self showConnectingView];

--- a/Source/Classes/MULegalViewController.m
+++ b/Source/Classes/MULegalViewController.m
@@ -4,26 +4,46 @@
 
 #import "MULegalViewController.h"
 #import "MUOperatingSystem.h"
+#import <WebKit/WebKit.h>
 
-@interface MULegalViewController () <UIWebViewDelegate> {
-    IBOutlet UIWebView *_webView;
+@interface MULegalViewController () <WKNavigationDelegate> {
+    WKWebView *_webView;
 }
 @end
 
 @implementation MULegalViewController
 
 - (id) init {
-    if ((self = [super initWithNibName:@"MULegalViewController" bundle:nil])) {
+    if ((self = [super init])) {
         // ...
     }
     return self;
 }
 
-- (void) viewDidLoad {
-    [super viewDidLoad];
+- (void)dealloc {
+    [_webView release];
+    [super dealloc];
+}
+
+- (void)loadView {
+    UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
+    self.view = view;
+    [view release];
+
+    _webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    _webView.navigationDelegate = self;
     _webView.backgroundColor = [UIColor clearColor];
     _webView.opaque = NO;
-    _webView.delegate = self;
+    [self.view addSubview:_webView];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    _webView.frame = self.view.bounds;
+}
+
+- (void) viewDidLoad {
+    [super viewDidLoad];
 }
 
 - (void) viewWillAppear:(BOOL)animated {
@@ -49,7 +69,7 @@
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }
 
-- (void) webViewDidFinishLoad:(UIWebView *)webView {
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     _webView.backgroundColor = [UIColor blackColor];
     _webView.opaque = YES;
 }

--- a/Source/Classes/MUPublicServerList.m
+++ b/Source/Classes/MUPublicServerList.m
@@ -19,8 +19,7 @@
 @end
 
 @interface MUPublicServerListFetcher () {
-    NSURLConnection *_conn;
-    NSMutableData   *_buf;
+    NSURLSessionDataTask *_task;
 }
 @end
 
@@ -34,25 +33,24 @@
 }
 
 - (void) dealloc {
+    [_task cancel];
+    [_task release];
     [super dealloc];
 }
 
 - (void) attemptUpdate {
-    NSURLRequest *req = [NSURLRequest requestWithURL:[MKServices regionalServerListURL]];
-    _conn = [[NSURLConnection alloc] initWithRequest:req delegate:self];
-    _buf = [[NSMutableData alloc] init];
+    NSURL *url = [MKServices regionalServerListURL];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    __block typeof(self) bself = self;
+    _task = [session dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (!error && data) {
+            [data writeToFile:[MUPublicServerList filePath] atomically:YES];
+        }
+    }];
+    [_task resume];
 }
 
-- (void) connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
-    [_buf appendData:data];
-}
 
-- (void) connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
-}
-
-- (void) connectionDidFinishLoading:(NSURLConnection *)connection {
-    [_buf writeToFile:[MUPublicServerList filePath] atomically:YES];
-}
 
 
 @end

--- a/Source/Classes/MUVersionChecker.m
+++ b/Source/Classes/MUVersionChecker.m
@@ -5,12 +5,8 @@
 #import "MUVersionChecker.h"
 
 @interface MUVersionChecker () {
-    NSURLConnection *_conn;
-    NSMutableData   *_buf;
+    NSURLSessionDataTask *_task;
 }
-- (void) connection:(NSURLConnection *)conn didReceiveData:(NSData *)data;
-- (void) connection:(NSURLConnection *)conn didFailWithError:(NSError *)error;
-- (void) connectionDidFinishLoading:(NSURLConnection *)conn;
 - (void) newBuildAvailable;
 @end
 
@@ -21,31 +17,30 @@
     if (!self)
         return nil;
 
-    NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://mumble-ios.appspot.com/latest.plist"]];
-    _conn = [[NSURLConnection alloc] initWithRequest:req delegate:self];
-    _buf = [[NSMutableData alloc] init];
+    NSURL *url = [NSURL URLWithString:@"https://mumble-ios.appspot.com/latest.plist"];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    __block typeof(self) bself = self;
+    _task = [session dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error || !data) {
+            NSLog(@"MUversionChecker: failed to fetch latest version info.");
+            return;
+        }
+        [bself parseData:data];
+    }];
+    [_task resume];
 
     return self;
 }
 
 - (void) dealloc {
-    [_conn cancel];
-    [_conn release];
-    [_buf release];
+    [_task cancel];
+    [_task release];
     [super dealloc];
 }
 
-- (void) connection:(NSURLConnection *)conn didReceiveData:(NSData *)data {
-    [_buf appendData:data];
-}
-
-- (void) connection:(NSURLConnection *)conn didFailWithError:(NSError *)error {
-    NSLog(@"MUversionChecker: failed to fetch latest version info.");
-}
-
-- (void) connectionDidFinishLoading:(NSURLConnection *)conn {
+- (void)parseData:(NSData *)data {
     NSPropertyListFormat fmt = NSPropertyListXMLFormat_v1_0;
-    NSDictionary *dict = [NSPropertyListSerialization propertyListWithData:_buf options:0 format:&fmt error:nil];
+    NSDictionary *dict = [NSPropertyListSerialization propertyListWithData:data options:0 format:&fmt error:nil];
     if (dict) {
         NSBundle *mainBundle = [NSBundle mainBundle];
         NSString *ourRev = [mainBundle objectForInfoDictionaryKey:@"MumbleGitRevision"];

--- a/Source/Classes/MUWelcomeScreenPad.m
+++ b/Source/Classes/MUWelcomeScreenPad.m
@@ -157,23 +157,9 @@
     }
 }
 
+
 #pragma mark -
 #pragma mark About Dialog
-
-- (void) alertView:(UIAlertView *)alert didDismissWithButtonIndex:(NSInteger)buttonIndex {
-    if (buttonIndex == 1) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.mumbleapp.com/"]];
-    } else if (buttonIndex == 2) {
-        MULegalViewController *legalView = [[MULegalViewController alloc] init];
-        UINavigationController *navController = [[UINavigationController alloc] init];
-        [navController pushViewController:legalView animated:NO];
-        [legalView release];
-        [[self navigationController] presentModalViewController:navController animated:YES];
-        [navController release];
-    } else if (buttonIndex == 3) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
-    }
-}
 
 #pragma mark - Actions
 
@@ -188,13 +174,37 @@
 #endif
     NSString *aboutMessage = NSLocalizedString(@"Low latency, high quality voice chat", nil);
     
-    UIAlertView *aboutView = [[UIAlertView alloc] initWithTitle:aboutTitle message:aboutMessage delegate:self
-                                              cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                              otherButtonTitles:NSLocalizedString(@"Website", nil),
-                              NSLocalizedString(@"Legal", nil),
-                              NSLocalizedString(@"Support", nil), nil];
-    [aboutView show];
-    [aboutView release];
+    UIAlertController *aboutView = [UIAlertController alertControllerWithTitle:aboutTitle
+                                                                       message:aboutMessage
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *ok = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                 style:UIAlertActionStyleCancel
+                                               handler:nil];
+    UIAlertAction *website = [UIAlertAction actionWithTitle:NSLocalizedString(@"Website", nil)
+                                                     style:UIAlertActionStyleDefault
+                                                   handler:^(UIAlertAction *a){
+                                                       [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.mumbleapp.com/"]];
+                                                   }];
+    UIAlertAction *legal = [UIAlertAction actionWithTitle:NSLocalizedString(@"Legal", nil)
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction *a){
+                                                     MULegalViewController *legalView = [[MULegalViewController alloc] init];
+                                                     UINavigationController *navController = [[UINavigationController alloc] init];
+                                                     [navController pushViewController:legalView animated:NO];
+                                                     [legalView release];
+                                                     [[self navigationController] presentModalViewController:navController animated:YES];
+                                                     [navController release];
+                                                 }];
+    UIAlertAction *support = [UIAlertAction actionWithTitle:NSLocalizedString(@"Support", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction *a){
+                                                      [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
+                                                  }];
+    [aboutView addAction:ok];
+    [aboutView addAction:website];
+    [aboutView addAction:legal];
+    [aboutView addAction:support];
+    [self presentViewController:aboutView animated:YES completion:nil];
 }
 
 - (void) prefsButtonClicked:(id)sender {

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -194,7 +194,7 @@
 
 - (void) alertView:(UIAlertView *)alert didDismissWithButtonIndex:(NSInteger)buttonIndex {
     if (buttonIndex == 1) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.mumbleapp.com/"]];
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.mumbleapp.com/"]];
     } else if (buttonIndex == 2) {
         MULegalViewController *legalView = [[MULegalViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] init];


### PR DESCRIPTION
## Summary
- migrate version check and public server list fetching to NSURLSession
- present legal content via WKWebView
- modernize connection and welcome alerts with UIAlertController
- use HTTPS URLs where supported

## Testing
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_e_6840d68eab848330880d7df2a07216e8