### PR TITLE
Remove personal signing info

### DIFF
--- a/BuildConfig/Release.xcconfig
+++ b/BuildConfig/Release.xcconfig
@@ -6,7 +6,7 @@
 
 COPY_PHASE_STRIP = YES
 
-CODE_SIGN_IDENTITY = iPhone Distribution: Mikkel Krautz
+CODE_SIGN_IDENTITY = iPhone Distribution
 
 GCC_FAST_MATH = YES
 GCC_UNROLL_LOOPS = YES


### PR DESCRIPTION
## Summary
- use a generic signing identity in Release build config

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d91808508330898b442d38c1239d