### PR TITLE
Fix trailing whitespace in header

### DIFF
--- a/Source/Classes/MUOperatingSystem.h
+++ b/Source/Classes/MUOperatingSystem.h
@@ -4,7 +4,7 @@
 
 typedef NS_ENUM(NSInteger, MUOperatingSystemVersion) {
     MUMBLE_OS_UNKNOWN,
-    
+
     MUMBLE_OS_IOS_5,
     MUMBLE_OS_IOS_6,
     MUMBLE_OS_IOS_7,


### PR DESCRIPTION
## Summary
- remove stray whitespace in `MUOperatingSystem.h`

## Testing
- `grep -n "[[:space:]]$" -n Source/Classes/MUOperatingSystem.h`

------
https://chatgpt.com/codex/tasks/task_e_6840cbb7a9208330b3bcb67c8993d6ad