### PR TITLE
Remove deprecated UILaunchImages

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -74,29 +74,6 @@
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
-	<key>UILaunchImages</key>
-	<array>
-		<dict>
-			<key>UILaunchImageMinimumOSVersion</key>
-			<string>7.0</string>
-			<key>UILaunchImageName</key>
-			<string>Default-iOS7</string>
-			<key>UILaunchImageOrientation</key>
-			<string>Portrait</string>
-			<key>UILaunchImageSize</key>
-			<string>{320, 480}</string>
-		</dict>
-		<dict>
-			<key>UILaunchImageMinimumOSVersion</key>
-			<string>7.0</string>
-			<key>UILaunchImageName</key>
-			<string>Default-iOS7</string>
-			<key>UILaunchImageOrientation</key>
-			<string>Portrait</string>
-			<key>UILaunchImageSize</key>
-			<string>{320, 568}</string>
-		</dict>
-	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIPrerenderedIcon</key>


### PR DESCRIPTION
## Summary
- update Info.plist to rely on Launch Screen storyboard

## Testing
- `grep -n UILaunchImages -n Source/Info.plist`


------
https://chatgpt.com/codex/tasks/task_e_68408a5729488330a8037e1960a459f6