### PR TITLE
Handle orientation with modern APIs

### DIFF
--- a/Source/Classes/MUAccessTokenViewController.m
+++ b/Source/Classes/MUAccessTokenViewController.m
@@ -86,8 +86,12 @@
     [_tokens release];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUAdvancedAudioPreferencesViewController.m
+++ b/Source/Classes/MUAdvancedAudioPreferencesViewController.m
@@ -62,8 +62,12 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUAudioQualityPreferencesViewController.m
+++ b/Source/Classes/MUAudioQualityPreferencesViewController.m
@@ -43,8 +43,12 @@
     self.tableView.scrollEnabled = NO;
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUAudioSidetonePreferencesViewController.m
+++ b/Source/Classes/MUAudioSidetonePreferencesViewController.m
@@ -43,8 +43,12 @@
     self.tableView.scrollEnabled = NO;
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUAudioTransmissionPreferencesViewController.m
+++ b/Source/Classes/MUAudioTransmissionPreferencesViewController.m
@@ -70,9 +70,12 @@
     [super viewDidDisappear:animated];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    // Return YES for supported orientations
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUCountryServerListController.m
+++ b/Source/Classes/MUCountryServerListController.m
@@ -93,8 +93,12 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark -

--- a/Source/Classes/MUFavouriteServerEditViewController.m
+++ b/Source/Classes/MUFavouriteServerEditViewController.m
@@ -195,13 +195,15 @@
     [super dealloc];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
-    // On iPad, we support all interface orientations.
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-        return YES;
+        return UIInterfaceOrientationMaskAll;
     }
-    
-    return toInterfaceOrientation == UIInterfaceOrientationPortrait;
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark -

--- a/Source/Classes/MUFavouriteServerListController.m
+++ b/Source/Classes/MUFavouriteServerListController.m
@@ -42,13 +42,16 @@
     [super dealloc];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
-    // On iPad, we support all interface orientations.
+
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-        return YES;
+        return UIInterfaceOrientationMaskAll;
     }
-    
-    return toInterfaceOrientation == UIInterfaceOrientationPortrait;
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 - (void) viewWillAppear:(BOOL)animated {

--- a/Source/Classes/MUImageViewController.m
+++ b/Source/Classes/MUImageViewController.m
@@ -99,8 +99,12 @@
     [actionButton release];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/Source/Classes/MULegalViewController.m
+++ b/Source/Classes/MULegalViewController.m
@@ -45,8 +45,12 @@
     [_webView loadData:html MIMEType:@"text/html" textEncodingName:@"utf-8" baseURL:nil];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 - (void) webViewDidFinishLoad:(UIWebView *)webView {

--- a/Source/Classes/MUMessageAttachmentViewController.m
+++ b/Source/Classes/MUMessageAttachmentViewController.m
@@ -50,8 +50,12 @@
     }
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUMessageRecipientViewController.m
+++ b/Source/Classes/MUMessageRecipientViewController.m
@@ -131,8 +131,12 @@
     [super viewDidDisappear:animated];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUMessagesViewController.m
+++ b/Source/Classes/MUMessagesViewController.m
@@ -283,8 +283,12 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
     [super viewDidDisappear:animated];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 - (void) scrollViewDidScroll:(UIScrollView *)scrollView {

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -149,13 +149,15 @@
     [super viewWillAppear:animated];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    // On iPad, we support all interface orientations.
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-        return YES;
+        return UIInterfaceOrientationMaskAll;
     }
+    return UIInterfaceOrientationMaskPortrait;
+}
 
-    return interfaceOrientation == UIInterfaceOrientationPortrait;
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 - (void) segmentChanged:(id)sender {

--- a/Source/Classes/MUVoiceActivitySetupViewController.m
+++ b/Source/Classes/MUVoiceActivitySetupViewController.m
@@ -46,8 +46,12 @@
     self.tableView.scrollEnabled = NO;
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark - Table view data source

--- a/Source/Classes/MUWelcomeScreenPad.m
+++ b/Source/Classes/MUWelcomeScreenPad.m
@@ -73,8 +73,12 @@
     [self setViewPositions];
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return YES;
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskAll;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 - (void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -80,8 +80,12 @@
 #endif
 }
 
-- (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
-    return toInterfaceOrientation == UIInterfaceOrientationPortrait;
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (UIInterfaceOrientation) preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
 
 #pragma mark -


### PR DESCRIPTION
## Summary
- remove deprecated `shouldAutorotateToInterfaceOrientation:` implementations
- implement `supportedInterfaceOrientations` and `preferredInterfaceOrientationForPresentation`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6840894108ec8330aa6a873cffae876d