### PR TITLE
Add xtool build integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+XT_PRODUCT = Mumble   # app bundle name
+
+.PHONY: setup build run pack install clean
+
+setup:
+	xtool setup
+
+build:
+	xtool dev build
+
+run:
+	xtool dev run
+
+pack:
+	xtool pack
+
+install:
+	xtool install xtool/$(XT_PRODUCT).ipa
+
+clean:
+	rm -rf .build xtool

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "Mumble",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "MumbleApp", targets: ["Mumble"])
+    ],
+    dependencies: [
+        // Local dependency expected at MumbleKit
+    ],
+    targets: [
+        .target(
+            name: "Mumble",
+            dependencies: ["MumbleKit"],
+            path: "Source",
+            sources: ["Classes", "main.m"],
+            resources: [
+                .copy("Classes/LaunchScreen.storyboard"),
+                .copy("MainWindow.xib")
+            ],
+            publicHeadersPath: "Classes",
+        ),
+        .target(
+            name: "MumbleKit",
+            path: "MumbleKit",
+            publicHeadersPath: "."
+        )
+    ]
+)

--- a/README.markdown
+++ b/README.markdown
@@ -46,3 +46,18 @@ We also recommend you to edit the default scheme for the Mumble target
 and change the Archive configuration to BetaDist, and the Test configuration
 to Release (debug builds pretty slow for devices, but for the Simulator, they're
 OK!)
+
+Cross-platform building with xtool
+---------------------------------
+
+Mumble can also be built using [xtool](https://github.com/segiddins/xtool). Make
+sure `xtool` is installed and available in your `PATH`.
+
+The provided `Makefile` exposes convenient targets for building or running the
+app using xtool:
+
+    make build  # builds Mumble for iOS 9-18
+    make run    # launches the app in the simulator
+
+Other targets such as `make pack` or `make install` package the app as an `.ipa`
+and install it on a connected device.

--- a/xtool.yml
+++ b/xtool.yml
@@ -1,0 +1,5 @@
+version: 1
+product: Mumble
+bundleID: info.mumble.Mumble
+deploymentTarget: 9.0
+infoPath: Source/Info.plist


### PR DESCRIPTION
## Summary
- add Makefile with xtool targets
- configure xtool.yml for iOS packaging
- create Package.swift referencing Objective-C sources
- document xtool workflow in README

## Testing
- `swift package describe` *(fails: duplicate rule and warnings)*
- `make build` *(fails: xtool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840745e2b988330a42a55f450e60fc3