### PR TITLE
Fix OpenSSL include path in SPM build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
             name: "MumbleKit",
             path: "MumbleKit",
             sources: ["src"],
-            publicHeadersPath: "src"
+            publicHeadersPath: "src",
+            cSettings: [
+                .headerSearchPath("3rdparty/openssl/include")
+            ]
         )
     ]
 )

--- a/Source/Classes/MULegalViewController.xib
+++ b/Source/Classes/MULegalViewController.xib
@@ -14,7 +14,6 @@
 			<string>IBProxyObject</string>
 			<string>IBUIView</string>
                        <string>IBWKWebView</string>
-                       <string>IBUIView</string>
 		</array>
 		<array key="IBDocument.PluginDependencies">
 			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -37,7 +36,6 @@
 				<int key="NSvFlags">274</int>
 				<array class="NSMutableArray" key="NSSubviews">
                                        <object class="IBWKWebView" id="827998242">
-                                       <object class="IBUIView" id="827998242">
 						<reference key="NSNextResponder" ref="191373211"/>
 						<int key="NSvFlags">274</int>
 						<string key="NSFrameSize">{320, 416}</string>
@@ -126,9 +124,8 @@
 				<string key="-2.CustomClassName">UIResponder</string>
 				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-                               <string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-                               <string key="4.CustomClassName">WKWebView</string>
-                       </dictionary>
+				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
@@ -143,14 +140,12 @@
 					<object class="NSMutableDictionary" key="outlets">
 						<string key="NS.key.0">_webView</string>
                                            <string key="NS.object.0">WKWebView</string>
-                               <string key="NS.object.0">WKWebView</string>
 					</object>
 					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
 						<string key="NS.key.0">_webView</string>
 						<object class="IBToOneOutletInfo" key="NS.object.0">
 							<string key="name">_webView</string>
                                                    <string key="candidateClassName">WKWebView</string>
-                                                       <string key="candidateClassName">WKWebView</string>
 						</object>
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">


### PR DESCRIPTION
## Summary
- point Swift Package Manager to OpenSSL headers so `openssl/aes.h` resolves

## Testing
- `swift test` *(fails: UIKit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a743d3938833092a222d4d8e9bdc8