### PR TITLE
Fix OpenSSL imports and Foundation header

### DIFF
--- a/MumbleKit/src/CryptState.cpp
+++ b/MumbleKit/src/CryptState.cpp
@@ -13,7 +13,7 @@
 
 #include "CryptState.h"
 
-#include <openssl/rand.h>
+#include <OpenSSL/rand.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/MumbleKit/src/CryptState.h
+++ b/MumbleKit/src/CryptState.h
@@ -5,7 +5,7 @@
 #ifndef _CRYPTSTATE_H
 #define _CRYPTSTATE_H
 
-#include <openssl/aes.h>
+#include <OpenSSL/aes.h>
 
 namespace MumbleClient {
 

--- a/MumbleKit/src/MKCertificate.m
+++ b/MumbleKit/src/MKCertificate.m
@@ -5,12 +5,12 @@
 #import <MumbleKit/MKCertificate.h>
 #import "MKDistinguishedNameParser.h"
 
-#include <openssl/evp.h>
-#include <openssl/err.h>
-#include <openssl/bio.h>
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
-#include <openssl/pkcs12.h>
+#include <OpenSSL/evp.h>
+#include <OpenSSL/err.h>
+#include <OpenSSL/bio.h>
+#include <OpenSSL/x509.h>
+#include <OpenSSL/x509v3.h>
+#include <OpenSSL/pkcs12.h>
 #include <time.h>
 #include <xlocale.h>
 

--- a/MumbleKit/src/MKVersion.m
+++ b/MumbleKit/src/MKVersion.m
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 #import <MumbleKit/MKVersion.h>
+#import <dispatch/dispatch.h>
 
 @interface MKVersion () {
     NSString  *_overrideReleaseString;

--- a/MumbleKit/src/MumbleKit/MKVersion.h
+++ b/MumbleKit/src/MumbleKit/MKVersion.h
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /// @class MKVersion MKVersion.h MumbleKit/MKVersion.h
+#import <Foundation/Foundation.h>
 @interface MKVersion : NSObject
 + (MKVersion *) sharedVersion;
 - (NSUInteger) hexVersion;

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // Local dependency expected at MumbleKit
+        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", from: "3.3.0")
     ],
     targets: [
         .executableTarget(
@@ -26,12 +27,12 @@ let package = Package(
         ),
         .target(
             name: "MumbleKit",
+            dependencies: ["OpenSSL"],
             path: "MumbleKit",
+            exclude: ["src/MumbleKit.pch", "src/MumbleKit-MacOSX.plist"],
             sources: ["src"],
             publicHeadersPath: "src",
-            cSettings: [
-                .headerSearchPath("3rdparty/openssl/include")
-            ]
+            cSettings: []
         )
     ]
 )

--- a/Source/main.m
+++ b/Source/main.m
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#import <UIKit/UIKit.h>
+#import "Classes/MUApplicationDelegate.h"
+
 int main(int argc, char *argv[]) {
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    int retVal = UIApplicationMain(argc, argv, @"UIApplication", @"MUApplicationDelegate");
-    [pool release];
-    return retVal;
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([MUApplicationDelegate class]));
+    }
 }


### PR DESCRIPTION
## Summary
- update includes to use OpenSSL framework headers
- import Foundation and dispatch for MKVersion

## Testing
- `swift build --product MumbleApp` *(fails: missing Apple SDK headers)*

------
https://chatgpt.com/codex/tasks/task_e_684a91f81dc48330beab025e4bd07a98