### PR TITLE
Add Swift wrapper for legal view controller

### DIFF
--- a/Source/Mumble-Bridging-Header.h
+++ b/Source/Mumble-Bridging-Header.h
@@ -1,2 +1,3 @@
 #import "MUVersionChecker.h"
 #import "MUOperatingSystem.h"
+#import "MULegalViewController.h"

--- a/Source/Swift/MULegalViewControllerWrapper.swift
+++ b/Source/Swift/MULegalViewControllerWrapper.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+@objc(MULegalViewControllerWrapper)
+class MULegalViewControllerWrapper: UIViewController {
+    private let objcController = MULegalViewController()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addChild(objcController)
+        objcController.view.frame = view.bounds
+        objcController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(objcController.view)
+        objcController.didMove(toParent: self)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        objcController.view.frame = view.bounds
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return objcController.supportedInterfaceOrientations
+    }
+
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        return objcController.preferredInterfaceOrientationForPresentation
+    }
+}


### PR DESCRIPTION
## Summary
- enable Swift access to MULegalViewController via bridging header
- add MULegalViewControllerWrapper in Swift to embed the Objective‑C view controller

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ba5e6b1ec833084a3e8f3f9fc394c