### PR TITLE
Fix protobuf header import

### DIFF
--- a/MumbleKit/src/MKConnection.m
+++ b/MumbleKit/src/MKConnection.m
@@ -29,7 +29,7 @@
 
 #include <celt.h>
 
-#import <MumbleKit/Mumble.pb.h>
+#import "Mumble.pb.h"
 
 // The bitstream we should send to the server.
 // It's currently hard-coded.

--- a/MumbleKit/src/MKServerModel.m
+++ b/MumbleKit/src/MKServerModel.m
@@ -8,7 +8,7 @@
 #import <MumbleKit/MKAudio.h>
 #import "MKPacketDataStream.h"
 #import "MKUtils.h"
-#import <MumbleKit/Mumble.pb.h>
+#import "Mumble.pb.h"
 
 #import <MumbleKit/MKChannel.h>
 #import "MKChannelPrivate.h"


### PR DESCRIPTION
## Summary
- fix path to `Mumble.pb.h` so that builds don't fail

## Testing
- `swift build` *(fails: 'Foundation/Foundation.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c92c742c8330aec85492fd07ff79