### PR TITLE
Fix protobuf header path

### DIFF
--- a/BuildConfig/Base.xcconfig
+++ b/BuildConfig/Base.xcconfig
@@ -16,7 +16,7 @@ TARGETED_DEVICE_FAMILY = 1 // iPhone
 
 ALWAYS_SEARCH_USER_PATHS = NO
 USER_HEADER_SEARCH_PATHS = 
-HEADER_SEARCH_PATHS = "${PROJECT_DIR}/MumbleKit/src/" "${PROJECT_DIR}/Dependencies/fmdb/src/" "${PROJECT_DIR}/Dependencies/gtm/" "${PROJECT_DIR}/Dependencies/MKNumberBadgeView/" "${PROJECT_DIR}/Dependencies/plcrashreporter/Source"
+HEADER_SEARCH_PATHS = "${PROJECT_DIR}/MumbleKit/src/" "${PROJECT_DIR}/MumbleKit/proto/" "${PROJECT_DIR}/Dependencies/fmdb/src/" "${PROJECT_DIR}/Dependencies/gtm/" "${PROJECT_DIR}/Dependencies/MKNumberBadgeView/" "${PROJECT_DIR}/Dependencies/plcrashreporter/Source"
 FRAMEWORK_SEARCH_PATHS = 
 
 OTHER_CFLAGS = -DNS_BLOCK_ASSERTIONS=1


### PR DESCRIPTION
## Summary
- keep protobuf header import using the MumbleKit style
- include `MumbleKit/proto` in the search path so the header is found

## Testing
- `swift build` *(fails: 'Foundation/Foundation.h' file not found)*
- `make build` *(fails: xtool: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6861c92c742c8330aec85492fd07ff79